### PR TITLE
Release/v0.2.2

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,4 @@
 ^docs$
 ^pkgdown$
 ^codecov\.yml$
+^.vscode$

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ vignettes/*.pdf
 *.DS_Store
 inst/doc
 docs
+
+# vscode
+.vscode

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flexpolyline
 Type: Package
 Title: Flexible Polyline Encoding
-Version: 0.2.1.9000
+Version: 0.2.2
 Authors@R:
     c(person(given = "Merlin",
              family = "Unterfinger",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# flexpolyline 0.2.1.9000
+# flexpolyline 0.2.2
 
 * Fix wrong integer shift resulting in lost bits for precision values greater than 7 (see [heremaps/flexible-polyline#36](https://github.com/heremaps/flexible-polyline/issues/36), closes [#44](https://github.com/munterfinger/flexpolyline/issues/44)).
 * Fix CRAN note for a specified lazy data statement without data directory (closes [#43](https://github.com/munterfinger/flexpolyline/issues/43)).

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -3,9 +3,10 @@
 
 #' Decode a flexible polyline encoded string
 #'
-#' This function calls \code{hf::polyline_decode} and \code{hf::get_third_dimension}
-#' of the C++ implementation of the flexible polyline encoding by HERE. Depending
-#' on the dimensions of the encoded line, a two or three dimensional line is decoded.
+#' This function calls \code{hf::polyline_decode} and
+#' \code{hf::get_third_dimension} of the C++ implementation of the flexible
+#' polyline encoding by HERE. Depending on the dimensions of the encoded line,
+#' a two or three dimensional line is decoded.
 #'
 #' @param encoded character, encoded flexible polyline string.
 #'
@@ -30,10 +31,14 @@ decode <- function(encoded) {
 #' the flexible polyline encoding by HERE. Depending on the dimensions of the
 #' input coordinates, a two or three dimensional line is encoded.
 #'
-#' @param line matrix, coordinates of the line in 2d or 3d (column order: LNG, LAT, DIM3).
-#' @param precision integer, precision to use in encoding (between 0 and 15, \code{default=5}).
-#' @param third_dim integer, type of the third dimension (0: ABSENT, 1: LEVEL, 2: ALTITUDE, 3: ELEVATION, 4, 6: CUSTOM1, 7: CUSTOM2, \code{default=3}).
-#' @param third_dim_precision integer, precision to use in encoding for the third dimension (between 1 and 15, \code{default=5}).
+#' @param line matrix, coordinates of the line in 2d or 3d (column order: LNG,
+#' LAT, DIM3).
+#' @param precision integer, precision to use in encoding (between 0 and 15,
+#' \code{default=5}).
+#' @param third_dim integer, type of the third dimension (0: ABSENT, 1: LEVEL,
+#' 2: ALTITUDE, 3: ELEVATION, 4, 6: CUSTOM1, 7: CUSTOM2, \code{default=3}).
+#' @param third_dim_precision integer, precision to use in encoding for the
+#' third dimension (between 1 and 15, \code{default=5}).
 #'
 #' @return
 #' The line as string in the flexible polyline encoding format.
@@ -93,12 +98,16 @@ get_third_dimension <- function(encoded) {
 #' dimension and encodes the line again.
 #'
 #' @note
-#' The precision is not read from the header of the encoded line. Therefore it must be provided as a parameter for re-encoding.
+#' The precision is not read from the header of the encoded line. Therefore it
+#' must be provided as a parameter for re-encoding.
 #'
 #' @param encoded character, encoded flexible polyline string.
-#' @param third_dim_name character, name of the third dimension to set (ABSENT, LEVEL, ALTITUDE, ELEVATION, CUSTOM1, CUSTOM2).
-#' @param precision integer, precision to use in encoding (between 0 and 15, \code{default=5}).
-#' @param third_dim_precision integer, precision to use in encoding for the third dimension (between 1 and 15, \code{default=5}).
+#' @param third_dim_name character, name of the third dimension to set (ABSENT,
+#' LEVEL, ALTITUDE, ELEVATION, CUSTOM1, CUSTOM2).
+#' @param precision integer, precision to use in encoding (between 0 and 15,
+#' \code{default=5}).
+#' @param third_dim_precision integer, precision to use in encoding for the
+#' third dimension (between 1 and 15, \code{default=5}).
 #'
 #' @return
 #' The line with the new third dimension as string in the flexible polyline

--- a/man/decode.Rd
+++ b/man/decode.Rd
@@ -13,9 +13,10 @@ decode(encoded)
 A matrix containing the coordinates of the decoded line.
 }
 \description{
-This function calls \code{hf::polyline_decode} and \code{hf::get_third_dimension}
-of the C++ implementation of the flexible polyline encoding by HERE. Depending
-on the dimensions of the encoded line, a two or three dimensional line is decoded.
+This function calls \code{hf::polyline_decode} and
+\code{hf::get_third_dimension} of the C++ implementation of the flexible
+polyline encoding by HERE. Depending on the dimensions of the encoded line,
+a two or three dimensional line is decoded.
 }
 \examples{
 # 2d line

--- a/man/encode.Rd
+++ b/man/encode.Rd
@@ -7,13 +7,17 @@
 encode(line, precision = 5L, third_dim = 3L, third_dim_precision = 5L)
 }
 \arguments{
-\item{line}{matrix, coordinates of the line in 2d or 3d (column order: LNG, LAT, DIM3).}
+\item{line}{matrix, coordinates of the line in 2d or 3d (column order: LNG,
+LAT, DIM3).}
 
-\item{precision}{integer, precision to use in encoding (between 0 and 15, \code{default=5}).}
+\item{precision}{integer, precision to use in encoding (between 0 and 15,
+\code{default=5}).}
 
-\item{third_dim}{integer, type of the third dimension (0: ABSENT, 1: LEVEL, 2: ALTITUDE, 3: ELEVATION, 4, 6: CUSTOM1, 7: CUSTOM2, \code{default=3}).}
+\item{third_dim}{integer, type of the third dimension (0: ABSENT, 1: LEVEL,
+2: ALTITUDE, 3: ELEVATION, 4, 6: CUSTOM1, 7: CUSTOM2, \code{default=3}).}
 
-\item{third_dim_precision}{integer, precision to use in encoding for the third dimension (between 1 and 15, \code{default=5}).}
+\item{third_dim_precision}{integer, precision to use in encoding for the
+third dimension (between 1 and 15, \code{default=5}).}
 }
 \value{
 The line as string in the flexible polyline encoding format.

--- a/man/set_third_dimension.Rd
+++ b/man/set_third_dimension.Rd
@@ -14,11 +14,14 @@ set_third_dimension(
 \arguments{
 \item{encoded}{character, encoded flexible polyline string.}
 
-\item{third_dim_name}{character, name of the third dimension to set (ABSENT, LEVEL, ALTITUDE, ELEVATION, CUSTOM1, CUSTOM2).}
+\item{third_dim_name}{character, name of the third dimension to set (ABSENT,
+LEVEL, ALTITUDE, ELEVATION, CUSTOM1, CUSTOM2).}
 
-\item{precision}{integer, precision to use in encoding (between 0 and 15, \code{default=5}).}
+\item{precision}{integer, precision to use in encoding (between 0 and 15,
+\code{default=5}).}
 
-\item{third_dim_precision}{integer, precision to use in encoding for the third dimension (between 1 and 15, \code{default=5}).}
+\item{third_dim_precision}{integer, precision to use in encoding for the
+third dimension (between 1 and 15, \code{default=5}).}
 }
 \value{
 The line with the new third dimension as string in the flexible polyline
@@ -29,7 +32,8 @@ This function decodes the flexible polyline encoded line, changes the third
 dimension and encodes the line again.
 }
 \note{
-The precision is not read from the header of the encoded line. Therefore it must be provided as a parameter for re-encoding.
+The precision is not read from the header of the encoded line. Therefore it
+must be provided as a parameter for re-encoding.
 }
 \examples{
 # 2d line (nothing happens...)

--- a/src/flexpolyline.cpp
+++ b/src/flexpolyline.cpp
@@ -1,16 +1,19 @@
-#include <Rcpp.h>
-#include <sstream>
-#include <vector>
-#include <tuple>
-#include <iostream>
 #include "hf/flexpolyline.h"
+
+#include <Rcpp.h>
+
+#include <iostream>
+#include <sstream>
+#include <tuple>
+#include <vector>
 using namespace Rcpp;
 
 //' Decode a flexible polyline encoded string
 //'
-//' This function calls \code{hf::polyline_decode} and \code{hf::get_third_dimension}
-//' of the C++ implementation of the flexible polyline encoding by HERE. Depending
-//' on the dimensions of the encoded line, a two or three dimensional line is decoded.
+//' This function calls \code{hf::polyline_decode} and
+//' \code{hf::get_third_dimension} of the C++ implementation of the flexible
+//' polyline encoding by HERE. Depending on the dimensions of the encoded line,
+//' a two or three dimensional line is decoded.
 //'
 //' @param encoded character, encoded flexible polyline string.
 //'
@@ -27,56 +30,52 @@ using namespace Rcpp;
 //' decode("BlBoz5xJ67i1BU1B7PUzIhaUxL7YU")
 // [[Rcpp::export]]
 NumericMatrix decode(SEXP encoded) {
+    // Convert from R SEXP to std::string
+    std::string encoded_str = Rcpp::as<std::string>(encoded);
 
-  // Convert from R SEXP to std::string
-  std::string encoded_str = Rcpp::as<std::string>(encoded);
+    // Initialize decoder
+    std::vector<std::tuple<double, double, double>> polyline;
+    auto res = hf::polyline_decode(
+        encoded_str, [&polyline](double lat, double lng, double z) {
+            polyline.push_back(std::make_tuple(lat, lng, z));
+        });
 
-  // Initialize decoder
-  std::vector<std::tuple<double, double, double>> polyline;
-  auto res = hf::polyline_decode(
-    encoded_str, [&polyline](double lat, double lng, double z) {
-    polyline.push_back(std::make_tuple(lat, lng, z));
-  });
-
-  // Check valid encoding
-  if (!res) {
-    throw std::invalid_argument("Invalid encoding");
-  }
-
-  // Extract third dimension type
-  const char * dim_name[] = {
-    "ABSENT", "LEVEL", "ALTITUDE", "ELEVATION",
-    "RESERVED1", "RESERVED2", // Should not be used...
-    "CUSTOM1", "CUSTOM2"
-  };
-  hf::ThirdDim thrd = hf::get_third_dimension(encoded_str);
-  int index = static_cast<std::underlying_type<hf::ThirdDim>::type>(thrd);
-
-  // Get line coordinates
-  size_t n = polyline.size();
-  NumericMatrix coords(n, 2 + !!index);
-
-  if (!!index) {
-
-    // 3d case (index > 0)
-    for (size_t i = 0; i < n; ++i) {
-      coords( i, 0 ) = std::get<1>(polyline[i]);
-      coords( i, 1 ) = std::get<0>(polyline[i]);
-      coords( i, 2 ) = std::get<2>(polyline[i]);
+    // Check valid encoding
+    if (!res) {
+        throw std::invalid_argument("Invalid encoding");
     }
-    colnames(coords) = CharacterVector({"LNG", "LAT", dim_name[index]});
 
-  } else {
+    // Extract third dimension type
+    const char* dim_name[] = {
+        "ABSENT",    "LEVEL",     "ALTITUDE",
+        "ELEVATION", "RESERVED1", "RESERVED2",  // Should not be used...
+        "CUSTOM1",   "CUSTOM2"};
+    hf::ThirdDim thrd = hf::get_third_dimension(encoded_str);
+    int index = static_cast<std::underlying_type<hf::ThirdDim>::type>(thrd);
 
-    // 2d case, third dimension ABSENT (index == 0)
-    for (size_t i = 0; i < n; ++i) {
-      coords( i, 0 ) = std::get<1>(polyline[i]);
-      coords( i, 1 ) = std::get<0>(polyline[i]);
+    // Get line coordinates
+    size_t n = polyline.size();
+    NumericMatrix coords(n, 2 + !!index);
+
+    if (!!index) {
+        // 3d case (index > 0)
+        for (size_t i = 0; i < n; ++i) {
+            coords(i, 0) = std::get<1>(polyline[i]);
+            coords(i, 1) = std::get<0>(polyline[i]);
+            coords(i, 2) = std::get<2>(polyline[i]);
+        }
+        colnames(coords) = CharacterVector({"LNG", "LAT", dim_name[index]});
+
+    } else {
+        // 2d case, third dimension ABSENT (index == 0)
+        for (size_t i = 0; i < n; ++i) {
+            coords(i, 0) = std::get<1>(polyline[i]);
+            coords(i, 1) = std::get<0>(polyline[i]);
+        }
+        colnames(coords) = CharacterVector({"LNG", "LAT"});
     }
-    colnames(coords) = CharacterVector({"LNG", "LAT"});
-  }
 
-  return coords;
+    return coords;
 }
 
 //' Encode a line in the flexible polyline encoding format
@@ -85,10 +84,14 @@ NumericMatrix decode(SEXP encoded) {
 //' the flexible polyline encoding by HERE. Depending on the dimensions of the
 //' input coordinates, a two or three dimensional line is encoded.
 //'
-//' @param line matrix, coordinates of the line in 2d or 3d (column order: LNG, LAT, DIM3).
-//' @param precision integer, precision to use in encoding (between 0 and 15, \code{default=5}).
-//' @param third_dim integer, type of the third dimension (0: ABSENT, 1: LEVEL, 2: ALTITUDE, 3: ELEVATION, 4, 6: CUSTOM1, 7: CUSTOM2, \code{default=3}).
-//' @param third_dim_precision integer, precision to use in encoding for the third dimension (between 1 and 15, \code{default=5}).
+//' @param line matrix, coordinates of the line in 2d or 3d (column order: LNG,
+//' LAT, DIM3).
+//' @param precision integer, precision to use in encoding (between 0 and 15,
+//' \code{default=5}).
+//' @param third_dim integer, type of the third dimension (0: ABSENT, 1: LEVEL,
+//' 2: ALTITUDE, 3: ELEVATION, 4, 6: CUSTOM1, 7: CUSTOM2, \code{default=3}).
+//' @param third_dim_precision integer, precision to use in encoding for the
+//' third dimension (between 1 and 15, \code{default=5}).
 //'
 //' @return
 //' The line as string in the flexible polyline encoding format.
@@ -116,44 +119,38 @@ NumericMatrix decode(SEXP encoded) {
 //' )
 //' encode(line3d)
 // [[Rcpp::export]]
-String encode(NumericMatrix line, int precision = 5,
-              int third_dim = 3, int third_dim_precision = 5) {
+String encode(NumericMatrix line, int precision = 5, int third_dim = 3,
+              int third_dim_precision = 5) {
+    String encoded;
+    size_t n = line.rows();
 
-  String encoded;
-  size_t n = line.rows();
+    if (line.cols() == 2) {
+        // 2d case: Set third dimension to ABSENT and third dimension precision
+        // to 0
+        std::vector<std::pair<double, double>> input;
+        for (size_t i = 0; i < n; ++i) {
+            input.push_back(std::make_pair(line(i, 1), line(i, 0)));
+        }
+        encoded =
+            hf::polyline_encode(input, precision, hf::ThirdDim::ABSENT, 0);
 
-  if (line.cols() == 2) {
+    } else if (line.cols() == 3) {
+        // 3d case: Use third dimension with third dimension precision
+        std::vector<std::tuple<double, double, double>> input;
+        for (size_t i = 0; i < n; ++i) {
+            input.push_back(
+                std::make_tuple(line(i, 1), line(i, 0), line(i, 2)));
+        }
+        encoded = hf::polyline_encode(input, precision,
+                                      static_cast<hf::ThirdDim>(third_dim),
+                                      third_dim_precision);
 
-    // 2d case: Set third dimension to ABSENT and third dimension precision to 0
-    std::vector<std::pair<double, double>> input;
-    for (size_t i = 0; i < n; ++i) {
-      input.push_back(
-        std::make_pair(line( i, 1 ), line( i, 0 ))
-      );
+    } else {
+        throw std::invalid_argument("Invalid input dimensions");
     }
-    encoded = hf::polyline_encode(input, precision, hf::ThirdDim::ABSENT, 0);
 
-  } else if (line.cols() == 3) {
-
-    // 3d case: Use third dimension with third dimension precision
-    std::vector<std::tuple<double, double, double>> input;
-    for (size_t i = 0; i < n; ++i) {
-      input.push_back(
-        std::make_tuple(line( i, 1 ), line( i, 0 ), line( i, 2 ))
-      );
-    }
-    encoded = hf::polyline_encode(
-      input, precision, static_cast<hf::ThirdDim>(third_dim), third_dim_precision
-    );
-
-  } else {
-
-    throw std::invalid_argument("Invalid input dimensions");
-  }
-
-  return encoded;
+    return encoded;
 }
-
 
 //' Get third dimension of a flexible polyline encoded string
 //'
@@ -176,21 +173,19 @@ String encode(NumericMatrix line, int precision = 5,
 //' get_third_dimension("BlBoz5xJ67i1BU1B7PUzIhaUxL7YU")
 // [[Rcpp::export]]
 std::string get_third_dimension(SEXP encoded) {
+    const char* dim_name[] = {
+        "ABSENT",    "LEVEL",     "ALTITUDE",
+        "ELEVATION", "RESERVED1", "RESERVED2",  // Should not be used...
+        "CUSTOM1",   "CUSTOM2"};
 
-  const char * dim_name[] = {
-    "ABSENT", "LEVEL", "ALTITUDE", "ELEVATION",
-    "RESERVED1", "RESERVED2", // Should not be used...
-    "CUSTOM1", "CUSTOM2"
-  };
+    // Convert from R SEXP to std::string
+    std::string encoded_str = Rcpp::as<std::string>(encoded);
 
-  // Convert from R SEXP to std::string
-  std::string encoded_str = Rcpp::as<std::string>(encoded);
+    // Extract third dimension type
+    hf::ThirdDim thrd = hf::get_third_dimension(encoded_str);
+    int index = static_cast<std::underlying_type<hf::ThirdDim>::type>(thrd);
 
-  // Extract third dimension type
-  hf::ThirdDim thrd = hf::get_third_dimension(encoded_str);
-  int index = static_cast<std::underlying_type<hf::ThirdDim>::type>(thrd);
-
-  return dim_name[index];
+    return dim_name[index];
 }
 
 //' Set third dimension of a flexible polyline encoded string
@@ -199,12 +194,16 @@ std::string get_third_dimension(SEXP encoded) {
 //' dimension and encodes the line again.
 //'
 //' @note
-//' The precision is not read from the header of the encoded line. Therefore it must be provided as a parameter for re-encoding.
+//' The precision is not read from the header of the encoded line. Therefore it
+//' must be provided as a parameter for re-encoding.
 //'
 //' @param encoded character, encoded flexible polyline string.
-//' @param third_dim_name character, name of the third dimension to set (ABSENT, LEVEL, ALTITUDE, ELEVATION, CUSTOM1, CUSTOM2).
-//' @param precision integer, precision to use in encoding (between 0 and 15, \code{default=5}).
-//' @param third_dim_precision integer, precision to use in encoding for the third dimension (between 1 and 15, \code{default=5}).
+//' @param third_dim_name character, name of the third dimension to set (ABSENT,
+//' LEVEL, ALTITUDE, ELEVATION, CUSTOM1, CUSTOM2).
+//' @param precision integer, precision to use in encoding (between 0 and 15,
+//' \code{default=5}).
+//' @param third_dim_precision integer, precision to use in encoding for the
+//' third dimension (between 1 and 15, \code{default=5}).
 //'
 //' @return
 //' The line with the new third dimension as string in the flexible polyline
@@ -219,36 +218,36 @@ std::string get_third_dimension(SEXP encoded) {
 //' # 3d line
 //' set_third_dimension("BlBoz5xJ67i1BU1B7PUzIhaUxL7YU", "ELEVATION")
 // [[Rcpp::export]]
-std::string set_third_dimension(SEXP encoded, SEXP third_dim_name, int precision = 5,
+std::string set_third_dimension(SEXP encoded, SEXP third_dim_name,
+                                int precision = 5,
                                 int third_dim_precision = 5) {
+    int third_dim_ind = -1;
+    const char* dim_name[] = {
+        "ABSENT",    "LEVEL",     "ALTITUDE",
+        "ELEVATION", "RESERVED1", "RESERVED2",  // Should not be used...
+        "CUSTOM1",   "CUSTOM2"};
 
-  int third_dim_ind = -1;
-  const char * dim_name[] = {
-    "ABSENT", "LEVEL", "ALTITUDE", "ELEVATION",
-    "RESERVED1", "RESERVED2", // Should not be used...
-    "CUSTOM1", "CUSTOM2"
-  };
+    // Convert from R SEXP to std::string
+    std::string third_dim_str = Rcpp::as<std::string>(third_dim_name);
 
-  // Convert from R SEXP to std::string
-  std::string third_dim_str = Rcpp::as<std::string>(third_dim_name);
+    // Decode
+    NumericMatrix decoded = decode(encoded);
 
-  // Decode
-  NumericMatrix decoded = decode(encoded);
-
-  // Match third dimension type
-  for (size_t i = 0; i != (sizeof dim_name / sizeof *dim_name); i++) {
-    if (dim_name[i] == third_dim_str) {
-      third_dim_ind = i;
+    // Match third dimension type
+    for (size_t i = 0; i != (sizeof dim_name / sizeof *dim_name); i++) {
+        if (dim_name[i] == third_dim_str) {
+            third_dim_ind = i;
+        }
     }
-  }
 
-  // Check if dimension is valid.
-  if (third_dim_ind == -1) {
-    throw std::invalid_argument("Invalid input name of third dimension");
-  }
+    // Check if dimension is valid.
+    if (third_dim_ind == -1) {
+        throw std::invalid_argument("Invalid input name of third dimension");
+    }
 
-  // Encode with new third dimension
-  String encoded_new = encode(decoded, precision, third_dim_ind, third_dim_precision);
+    // Encode with new third dimension
+    String encoded_new =
+        encode(decoded, precision, third_dim_ind, third_dim_precision);
 
-  return encoded_new;
+    return encoded_new;
 }


### PR DESCRIPTION
* Fix wrong integer shift resulting in lost bits for precision values greater than 7 (see [heremaps/flexible-polyline#36](https://github.com/heremaps/flexible-polyline/issues/36), closes #44).
* Fix CRAN note for a specified lazy data statement without data directory (closes #43).
* Use **styler** package and use `tyler::tidyverse_style()`to format the package.
* Solve **lintr** issues, except from line length issues (limit of 80 characters).