### PR TITLE
Release/v0.2.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flexpolyline
 Type: Package
 Title: Flexible Polyline Encoding
-Version: 0.2.2.9000
+Version: 0.2.3
 Authors@R:
     c(person(given = "Merlin",
              family = "Unterfinger",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flexpolyline
 Type: Package
 Title: Flexible Polyline Encoding
-Version: 0.2.2
+Version: 0.2.2.9000
 Authors@R:
     c(person(given = "Merlin",
              family = "Unterfinger",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# flexpolyline 0.2.2.9000
+# flexpolyline 0.2.3
 
 * Deactivate encoding and decoding validation tests on CRAN due to minor deviations in the results due to rounding (half up vs. half even) on different platforms (e.g. Apple M1) on high precision values (closes [#49](https://github.com/munterfinger/flexpolyline/issues/49))
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# flexpolyline 0.2.2.9000
+
 # flexpolyline 0.2.2
 
 * Fix wrong integer shift resulting in lost bits for precision values greater than 7 (see [heremaps/flexible-polyline#36](https://github.com/heremaps/flexible-polyline/issues/36), closes [#44](https://github.com/munterfinger/flexpolyline/issues/44)).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # flexpolyline 0.2.3
 
-* Deactivate encoding and decoding validation tests on CRAN due to minor deviations in the results due to rounding (half up vs. half even) on different platforms (e.g. Apple M1) on high precision values (closes [#49](https://github.com/munterfinger/flexpolyline/issues/49))
+* Skip encoding and decoding validation tests on CRAN due to minor deviations in the results due to rounding (half up vs. half even) on different platforms (e.g. Apple M1) at high precision values (closes [#49](https://github.com/munterfinger/flexpolyline/issues/49))
 
 # flexpolyline 0.2.2
 

--- a/tests/testthat/test-cpp_binding.R
+++ b/tests/testthat/test-cpp_binding.R
@@ -1,5 +1,6 @@
 test_that("Cpp binding to 'flexpolyline.h' en- and decodes correctly", {
 
+  # Skip tests on CRAN due to platform specific rounding at high precision
   skip_on_cran()
 
   # Get and set third dimension


### PR DESCRIPTION
* Skip encoding and decoding validation tests on CRAN due to minor deviations in the results due to rounding (half up vs. half even) on different platforms (e.g. Apple M1) at high precision values (closes [#49](https://github.com/munterfinger/flexpolyline/issues/49))